### PR TITLE
draft: first pass at fixing highlighting

### DIFF
--- a/syntax/nix.tmLanguage.json
+++ b/syntax/nix.tmLanguage.json
@@ -1180,6 +1180,11 @@
       "match": ".",
       "name": "invalid.illegal"
     },
+    "operator": {
+    {
+    "match": "[!:~\\+\\-&\\|\\^=<>\\*\\/%]",
+    "name": "keyword.operator.nix"
+    },
     "others": {
       "patterns": [
         {
@@ -1190,6 +1195,9 @@
         },
         {
           "include": "#illegal"
+        },
+        {
+          "include": "#operator"
         }
       ]
     },


### PR DESCRIPTION
this is taken from the JSONNET tmLanguage file that correctly highlights the `=` usage which is similar to nix's usage. see https://github.com/grafana/vscode-jsonnet/blob/main/language/jsonnet.tmLanguage.json#L166-#L169

fixes #6 and #4